### PR TITLE
Test: using arbitrarily IP address and existing config file

### DIFF
--- a/test/lib/bird.py
+++ b/test/lib/bird.py
@@ -20,8 +20,9 @@ class BirdContainer(BGPContainer):
     WAIT_FOR_BOOT = 1
     SHARED_VOLUME = '/etc/bird'
 
-    def __init__(self, name, asn, router_id, ctn_image_name='osrg/bird'):
+    def __init__(self, name, asn, router_id, ip_addr='', ctn_image_name='osrg/bird'):
         super(BirdContainer, self).__init__(name, asn, router_id,
+                                            ip_addr,
                                             ctn_image_name)
         self.shared_volumes.append((self.config_dir, self.SHARED_VOLUME))
 

--- a/test/lib/exabgp.py
+++ b/test/lib/exabgp.py
@@ -15,24 +15,25 @@
 
 from base import *
 from itertools import chain
+import shutil
 
 class ExaBGPContainer(BGPContainer):
 
     SHARED_VOLUME = '/root/shared_volume'
 
     def __init__(self, name, asn, router_id, ctn_image_name='osrg/exabgp',
-                 ip_addr='',
-                 exabgp_path=''):
+                 ip_addr='', config_file='', exabgp_path=''):
         super(ExaBGPContainer, self).__init__(name, asn, router_id,
                                               ip_addr,
                                               ctn_image_name)
         self.shared_volumes.append((self.config_dir, self.SHARED_VOLUME))
+        self.config_file = config_file
         self.exabgp_path = exabgp_path
 
     def _start_exabgp(self):
         cmd = CmdBuffer(' ')
         cmd << 'env exabgp.log.destination={0}/exabgpd.log'.format(self.SHARED_VOLUME)
-        cmd << "exabgp.tcp.bind='0.0.0.0' exabgp.tcp.port=179"
+        cmd << "exabgp.daemon.user=root exabgp.tcp.bind='0.0.0.0' exabgp.tcp.port=179"
         cmd << './exabgp/sbin/exabgp {0}/exabgpd.conf'.format(self.SHARED_VOLUME)
         self.local(str(cmd), detach=True)
 
@@ -64,6 +65,16 @@ class ExaBGPContainer(BGPContainer):
         return self.WAIT_FOR_BOOT
 
     def create_config(self):
+        if self.config_file:
+            try:
+                shutil.copyfile(self.config_file, '{0}/exabgpd.conf'.format(self.config_dir))
+                print colors.yellow('[read {0}\'s config from {1}]'.format(self.name, self.config_file))
+            except IOError as e:
+                raise Exception('IOError: {0}'.format(e))
+            except:
+                raise Exception('Error: ', sys.exc_info()[0])
+            return
+
         cmd = CmdBuffer()
         for peer, info in self.peers.iteritems():
             cmd << 'neighbor {0} {{'.format(info['neigh_addr'].split('/')[0])

--- a/test/lib/exabgp.py
+++ b/test/lib/exabgp.py
@@ -21,8 +21,10 @@ class ExaBGPContainer(BGPContainer):
     SHARED_VOLUME = '/root/shared_volume'
 
     def __init__(self, name, asn, router_id, ctn_image_name='osrg/exabgp',
+                 ip_addr='',
                  exabgp_path=''):
         super(ExaBGPContainer, self).__init__(name, asn, router_id,
+                                              ip_addr,
                                               ctn_image_name)
         self.shared_volumes.append((self.config_dir, self.SHARED_VOLUME))
         self.exabgp_path = exabgp_path

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -35,9 +35,11 @@ class GoBGPContainer(BGPContainer):
     QUAGGA_VOLUME = '/etc/quagga'
 
     def __init__(self, name, asn, router_id, ctn_image_name='osrg/gobgp',
+                 ip_addr='',
                  log_level='debug', zebra=False, config_format='toml',
                  zapi_version=2):
         super(GoBGPContainer, self).__init__(name, asn, router_id,
+                                             ip_addr,
                                              ctn_image_name)
         self.shared_volumes.append((self.config_dir, self.SHARED_VOLUME))
 

--- a/test/lib/gobgp.py
+++ b/test/lib/gobgp.py
@@ -22,6 +22,7 @@ from threading import Thread
 import socket
 import subprocess
 import os
+import shutil
 
 def extract_path_attribute(path, typ):
     for a in path['attrs']:
@@ -35,12 +36,11 @@ class GoBGPContainer(BGPContainer):
     QUAGGA_VOLUME = '/etc/quagga'
 
     def __init__(self, name, asn, router_id, ctn_image_name='osrg/gobgp',
-                 ip_addr='',
-                 log_level='debug', zebra=False, config_format='toml',
+                 ip_addr='', log_level='debug', zebra=False,
+                 config_file='', config_format='toml',
                  zapi_version=2):
         super(GoBGPContainer, self).__init__(name, asn, router_id,
-                                             ip_addr,
-                                             ctn_image_name)
+                                             ip_addr, ctn_image_name)
         self.shared_volumes.append((self.config_dir, self.SHARED_VOLUME))
 
         self.log_level = log_level
@@ -50,6 +50,7 @@ class GoBGPContainer(BGPContainer):
         self.default_policy = None
         self.zebra = zebra
         self.zapi_version = zapi_version
+        self.config_file = config_file
         self.config_format = config_format
 
     def _start_gobgp(self, graceful_restart=False):
@@ -247,9 +248,16 @@ class GoBGPContainer(BGPContainer):
         self.bgp_set = bs
 
     def create_config(self):
-        self._create_config_bgp()
-        if self.zebra:
-            self._create_config_zebra()
+        if self.config_file == '':
+            self._create_config_bgp()
+            if self.zebra:
+                self._create_config_zebra()
+        else:
+            try:
+                shutil.copyfile(self.config_file, '{0}/gobgpd.conf'.format(self.config_dir))
+                print colors.yellow('[read {0}\'s config from {1}]'.format(self.name, self.config_file))
+            except IOError as e:
+                raise Exception('IOError: {0}'.format(e))
 
     def _create_config_bgp(self):
         config = {'global': {'config': {'as': self.asn, 'router-id': self.router_id},

--- a/test/lib/quagga.py
+++ b/test/lib/quagga.py
@@ -22,8 +22,11 @@ class QuaggaBGPContainer(BGPContainer):
     WAIT_FOR_BOOT = 1
     SHARED_VOLUME = '/etc/quagga'
 
-    def __init__(self, name, asn, router_id, ctn_image_name='osrg/quagga', zebra=False):
+    def __init__(self, name, asn, router_id, ctn_image_name='osrg/quagga',
+                 ip_addr='',
+                 zebra=False):
         super(QuaggaBGPContainer, self).__init__(name, asn, router_id,
+                                                 ip_addr,
                                                  ctn_image_name)
         self.shared_volumes.append((self.config_dir, self.SHARED_VOLUME))
         self.zebra = zebra


### PR DESCRIPTION
This patch enables users to
- specify arbitrarily IP address by set 'ip_addr' option in container.
- use existing configuration file for GoBGP and ExaBGP by setting 'config_file' option in container.